### PR TITLE
Add Factories for Randomized Data Generation and Allow Nullable UUID for Registered Users

### DIFF
--- a/database/factories/AnswerFactory.php
+++ b/database/factories/AnswerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Question;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Answer>
+ */
+class AnswerFactory extends Factory
+{
+    protected $model = \App\Models\Answer::class;
+
+    public function definition()
+    {
+        return [
+            'question_id' => Question::factory(),
+            'label' => strtoupper($this->faker->randomElement(['A', 'B', 'C', 'D'])),
+            'content' => $this->faker->sentence(),
+            'image_src' => $this->faker->optional()->imageUrl(),
+            'image_alt' => $this->faker->optional()->words(3, true),
+            'is_correct' => $this->faker->boolean(25), // 25% chance of being correct
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/ExamSetFactory.php
+++ b/database/factories/ExamSetFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\ExamSet;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ExamSet>
+ */
+class ExamSetFactory extends Factory
+{
+    protected $model = \App\Models\ExamSet::class;
+
+    public function definition()
+    {
+        return [
+            'parent_id' => $this->faker->optional()->for(ExamSet::factory()->state(['is_exam' => false])),
+            'name' => $this->faker->words(3, true),
+            'slug' => $this->faker->unique()->slug(),
+            'is_exam' => $this->faker->boolean(50),
+            'children_sort_by' => 'id',
+            'children_sort_order' => 'ASC',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/ExplanationFactory.php
+++ b/database/factories/ExplanationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Question;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Explanation>
+ */
+class ExplanationFactory extends Factory
+{
+    protected $model = \App\Models\Explanation::class;
+
+    public function definition()
+    {
+        return [
+            'question_id' => Question::factory(),
+            'content' => $this->faker->paragraph(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/HttpRequestFactory.php
+++ b/database/factories/HttpRequestFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\User;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\HttpRequest>
+ */
+class HttpRequestFactory extends Factory
+{
+    protected $model = \App\Models\HttpRequest::class;
+
+    public function definition()
+    {
+        $httpMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'];
+
+        return [
+            'user_id' => User::factory(),
+            'http_method' => $this->faker->randomElement($httpMethods),
+            'path' => $this->faker->url(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\ExamSet;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Question>
+ */
+class QuestionFactory extends Factory
+{
+    protected $model = \App\Models\Question::class;
+
+    public function definition()
+    {
+        return [
+            'exam_set_id' => ExamSet::factory()->state(['is_exam' => true]),
+            'name' => $this->faker->sentence(),
+            'slug' => $this->faker->unique()->slug(),
+            'content' => $this->faker->paragraph(),
+            'image_src' => $this->faker->optional()->imageUrl(),
+            'image_alt' => $this->faker->optional()->words(3, true),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -11,30 +11,60 @@ use Illuminate\Support\Str;
 class UserFactory extends Factory
 {
     /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = \App\Models\User::class;
+
+    /**
      * Define the model's default state.
+     * By default, create an unregistered user with a UUID.
      *
      * @return array<string, mixed>
      */
     public function definition()
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'remember_token' => Str::random(10),
+            'uuid' => (string) Str::uuid(),
+            'created_at' => now(),
+            'updated_at' => now(),
         ];
     }
 
     /**
-     * Indicate that the model's email address should be unverified.
+     * Indicate that the user is registered.
+     * Registered users do not have a uuid.
      *
      * @return static
      */
-    public function unverified()
+    public function registered()
     {
         return $this->state(fn (array $attributes) => [
+            'uuid' => null,
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => bcrypt('password'),
+            'remember_token' => Str::random(10),
+        ]);
+    }
+
+    /**
+     * Indicate that the user is unregistered.
+     * Unregistered users have a UUID.
+     *
+     * @return static
+     */
+    public function unregistered()
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => null,
+            'email' => null,
             'email_verified_at' => null,
+            'password' => null,
+            'remember_token' => null,
+            // 'uuid' remains as defined in the default state
         ]);
     }
 }

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\User;
+use App\Models\Answer;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UserProgress>
+ */
+class UserProgressFactory extends Factory
+{
+    protected $model = \App\Models\UserProgress::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'answer_id' => Answer::factory(),
+            'is_active' => $this->faker->boolean(80), // 80% chance to be active
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+
+    /**
+     * Configure the factory with additional constraints.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterMaking(function (UserProgress $userProgress) {
+            if ($userProgress->is_active) {
+                // Ensure no duplicate answer_id for the same user when is_active == true
+                $existing = UserProgress::where('user_id', $userProgress->user_id)
+                    ->where('answer_id', $userProgress->answer_id)
+                    ->where('is_active', true)
+                    ->exists();
+
+                if ($existing) {
+                    // Generate a new answer_id to avoid duplication
+                    $userProgress->answer_id = Answer::factory()->create()->id;
+                }
+            }
+        });
+    }
+}

--- a/database/migrations/2024_10_24_104134_create_users_table.php
+++ b/database/migrations/2024_10_24_104134_create_users_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->char('uuid', 36)->unique('uid');
+            $table->char('uuid', 36)->unique('uid')->nullable();
             $table->string('name')->nullable();
             $table->string('email')->nullable()->unique('email');
             $table->timestamp('email_verified_at')->nullable();


### PR DESCRIPTION
This PR introduces new factories to generate random data for various models and modifies the `users` table migration to allow nullable UUIDs for registered users. The key updates include:

1. **Migration Update for UUIDs:**
   - Modified the `users` table migration to make the `uuid` column nullable, ensuring that registered users do not require a UUID. This allows more flexibility in the user creation process.

2. **New Data Factories:**
   - **AnswerFactory:** Generates random answer data, including optional image attributes and correctness flags.
   - **ExamSetFactory:** Creates random exam set data, supporting hierarchical relationships between exam sets and generating random exam characteristics.
   - **ExplanationFactory:** Generates random explanation data linked to questions, with randomized paragraph content.
   - **HttpRequestFactory:** Simulates random HTTP request data for users, including various methods and paths.
   - **QuestionFactory:** Produces random question data, with associations to exam sets and optional image attributes.
   - **UserProgressFactory:** Generates random user progress data, ensuring no duplicate active progress records and linking users with answers.

3. **UserFactory Enhancements:**
   - Added states to distinguish between registered and unregistered users:
     - **`registered()`**: Users with names, emails, and passwords.
     - **`unregistered()`**: Users identified only by UUID.

These additions improve the efficiency of testing by automating the creation of realistic data across different models while also providing greater flexibility in handling user records.