### PR TITLE
Refactor Seeder and Factory Logic for Correct `parent_id` Assignment, Slug Uniqueness, and Improved Data Consistency

### DIFF
--- a/app/Models/UserProgress.php
+++ b/app/Models/UserProgress.php
@@ -9,20 +9,8 @@ class UserProgress extends Model
 {
     use HasFactory;
 
-    /**
-     * Indicates if the model should be timestamped.
-     *
-     * @var bool
-     */
-    public $timestamps = true;
+    protected $table = 'user_progresses';
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * Allows mass assignment of these fields during model creation.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'user_id',
         'answer_id',
@@ -30,7 +18,7 @@ class UserProgress extends Model
     ];
 
     /**
-     * Get the user that owns the progress.
+     * Get the user associated with the progress.
      */
     public function user()
     {

--- a/database/factories/AnswerFactory.php
+++ b/database/factories/AnswerFactory.php
@@ -15,7 +15,6 @@ class AnswerFactory extends Factory
     public function definition()
     {
         return [
-            'question_id' => Question::factory(),
             'label' => strtoupper($this->faker->randomElement(['A', 'B', 'C', 'D'])),
             'content' => $this->faker->sentence(),
             'image_src' => $this->faker->optional()->imageUrl(),

--- a/database/factories/AnswerFactory.php
+++ b/database/factories/AnswerFactory.php
@@ -20,8 +20,6 @@ class AnswerFactory extends Factory
             'image_src' => $this->faker->optional()->imageUrl(),
             'image_alt' => $this->faker->optional()->words(3, true),
             'is_correct' => $this->faker->boolean(25), // 25% chance of being correct
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 }

--- a/database/factories/ExamSetFactory.php
+++ b/database/factories/ExamSetFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\ExamSet;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ExamSet>
@@ -14,14 +15,41 @@ class ExamSetFactory extends Factory
 
     public function definition()
     {
+        $name = $this->faker->words(3, true);
+        $slug = Str::slug($name);
+
+        // Ensure the slug is unique for the same parent_id
+        $parentId = $this->faker->optional()->randomElement(ExamSet::pluck('id')->toArray());
+        $slug = $this->uniqueSlugForParent($slug, $parentId);
+
         return [
-            'name' => $this->faker->words(3, true),
-            'slug' => $this->faker->unique()->slug(),
+            'parent_id' => $parentId,
+            'name' => $name,
+            'slug' => $slug,
             'is_exam' => $this->faker->boolean(50),
             'children_sort_by' => 'id',
             'children_sort_order' => 'ASC',
             'created_at' => now(),
             'updated_at' => now(),
         ];
+    }
+
+    /**
+     * Generate a unique slug for the specified parent_id.
+     *
+     * @param string $slug
+     * @param int|null $parentId
+     * @return string
+     */
+    protected function uniqueSlugForParent($slug, $parentId)
+    {
+        $originalSlug = $slug;
+        $counter = 1;
+
+        while (ExamSet::where('slug', $slug)->where('parent_id', $parentId)->exists()) {
+            $slug = $originalSlug . '-' . $counter++;
+        }
+
+        return $slug;
     }
 }

--- a/database/factories/ExamSetFactory.php
+++ b/database/factories/ExamSetFactory.php
@@ -15,9 +15,6 @@ class ExamSetFactory extends Factory
     public function definition()
     {
         return [
-            'parent_id' => $this->faker->optional()->state(function () {
-                return ExamSet::factory()->state(['is_exam' => false])->create()->id;
-            }),
             'name' => $this->faker->words(3, true),
             'slug' => $this->faker->unique()->slug(),
             'is_exam' => $this->faker->boolean(50),

--- a/database/factories/ExamSetFactory.php
+++ b/database/factories/ExamSetFactory.php
@@ -29,8 +29,6 @@ class ExamSetFactory extends Factory
             'is_exam' => $this->faker->boolean(50),
             'children_sort_by' => 'id',
             'children_sort_order' => 'ASC',
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 

--- a/database/factories/ExamSetFactory.php
+++ b/database/factories/ExamSetFactory.php
@@ -15,7 +15,9 @@ class ExamSetFactory extends Factory
     public function definition()
     {
         return [
-            'parent_id' => $this->faker->optional()->for(ExamSet::factory()->state(['is_exam' => false])),
+            'parent_id' => $this->faker->optional()->state(function () {
+                return ExamSet::factory()->state(['is_exam' => false])->create()->id;
+            }),
             'name' => $this->faker->words(3, true),
             'slug' => $this->faker->unique()->slug(),
             'is_exam' => $this->faker->boolean(50),

--- a/database/factories/ExplanationFactory.php
+++ b/database/factories/ExplanationFactory.php
@@ -16,8 +16,6 @@ class ExplanationFactory extends Factory
     {
         return [
             'content' => $this->faker->paragraph(),
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 }

--- a/database/factories/ExplanationFactory.php
+++ b/database/factories/ExplanationFactory.php
@@ -15,7 +15,6 @@ class ExplanationFactory extends Factory
     public function definition()
     {
         return [
-            'question_id' => Question::factory(),
             'content' => $this->faker->paragraph(),
             'created_at' => now(),
             'updated_at' => now(),

--- a/database/factories/HttpRequestFactory.php
+++ b/database/factories/HttpRequestFactory.php
@@ -20,8 +20,6 @@ class HttpRequestFactory extends Factory
             'user_id' => User::factory(),
             'http_method' => $this->faker->randomElement($httpMethods),
             'path' => $this->faker->url(),
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 }

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -15,7 +15,6 @@ class QuestionFactory extends Factory
     public function definition()
     {
         return [
-            'exam_set_id' => ExamSet::factory()->state(['is_exam' => true]),
             'name' => $this->faker->sentence(),
             'slug' => $this->faker->unique()->slug(),
             'content' => $this->faker->paragraph(),

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -3,7 +3,8 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\ExamSet;
+use App\Models\Question;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Question>
@@ -14,14 +15,41 @@ class QuestionFactory extends Factory
 
     public function definition()
     {
+        $name = $this->faker->sentence();
+        $slug = Str::slug($name);
+
+        // Ensure the slug is unique for the same exam_set_id
+        $examSetId = $this->faker->randomElement(\App\Models\ExamSet::pluck('id')->toArray());
+        $slug = $this->uniqueSlugForExamSet($slug, $examSetId);
+
         return [
-            'name' => $this->faker->sentence(),
-            'slug' => $this->faker->unique()->slug(),
+            'exam_set_id' => $examSetId,
+            'name' => $name,
+            'slug' => $slug,
             'content' => $this->faker->paragraph(),
             'image_src' => $this->faker->optional()->imageUrl(),
             'image_alt' => $this->faker->optional()->words(3, true),
             'created_at' => now(),
             'updated_at' => now(),
         ];
+    }
+
+    /**
+     * Generate a unique slug for the specified exam_set_id.
+     *
+     * @param string $slug
+     * @param int $examSetId
+     * @return string
+     */
+    protected function uniqueSlugForExamSet($slug, $examSetId)
+    {
+        $originalSlug = $slug;
+        $counter = 1;
+
+        while (Question::where('slug', $slug)->where('exam_set_id', $examSetId)->exists()) {
+            $slug = $originalSlug . '-' . $counter++;
+        }
+
+        return $slug;
     }
 }

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -29,8 +29,6 @@ class QuestionFactory extends Factory
             'content' => $this->faker->paragraph(),
             'image_src' => $this->faker->optional()->imageUrl(),
             'image_alt' => $this->faker->optional()->words(3, true),
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -27,8 +27,6 @@ class UserFactory extends Factory
     {
         return [
             'uuid' => (string) Str::uuid(),
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 
@@ -64,7 +62,6 @@ class UserFactory extends Factory
             'email_verified_at' => null,
             'password' => null,
             'remember_token' => null,
-            // 'uuid' remains as defined in the default state
         ]);
     }
 }

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -30,7 +30,7 @@ class UserProgressFactory extends Factory
      */
     public function configure()
     {
-        return $this->afterMaking(function (UserProgress $userProgress) {
+        return $this->afterCreating(function (UserProgress $userProgress) {
             if ($userProgress->is_active) {
                 // Ensure no duplicate answer_id for the same user when is_active is true
                 $existing = UserProgress::where('user_id', $userProgress->user_id)
@@ -41,6 +41,7 @@ class UserProgressFactory extends Factory
                 if ($existing) {
                     // Assign a new answer_id to avoid duplication from existing answers
                     $userProgress->answer_id = Answer::inRandomOrder()->value('id') ?: Answer::factory()->create()->id;
+                    $userProgress->save();
                 }
             }
         });

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -18,8 +18,6 @@ class UserProgressFactory extends Factory
         return [
             'answer_id' => Answer::inRandomOrder()->value('id') ?: Answer::factory()->create()->id,
             'is_active' => $this->faker->boolean(80), // 80% chance to be active
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -17,8 +17,6 @@ class UserProgressFactory extends Factory
     public function definition()
     {
         return [
-            'user_id' => User::factory(),
-            'answer_id' => Answer::factory(),
             'is_active' => $this->faker->boolean(80), // 80% chance to be active
             'created_at' => now(),
             'updated_at' => now(),

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -16,7 +16,7 @@ class UserProgressFactory extends Factory
     public function definition()
     {
         return [
-            'answer_id' => Answer::inRandomOrder()->value('id') ?: Answer::factory(),
+            'answer_id' => Answer::inRandomOrder()->value('id') ?: Answer::factory()->create()->id,
             'is_active' => $this->faker->boolean(80), // 80% chance to be active
             'created_at' => now(),
             'updated_at' => now(),

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
 use App\Models\Answer;
+use App\Models\UserProgress;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UserProgress>

--- a/database/factories/UserProgressFactory.php
+++ b/database/factories/UserProgressFactory.php
@@ -3,7 +3,6 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use App\Models\User;
 use App\Models\Answer;
 use App\Models\UserProgress;
 
@@ -17,6 +16,7 @@ class UserProgressFactory extends Factory
     public function definition()
     {
         return [
+            'answer_id' => Answer::inRandomOrder()->value('id') ?: Answer::factory(),
             'is_active' => $this->faker->boolean(80), // 80% chance to be active
             'created_at' => now(),
             'updated_at' => now(),
@@ -32,15 +32,15 @@ class UserProgressFactory extends Factory
     {
         return $this->afterMaking(function (UserProgress $userProgress) {
             if ($userProgress->is_active) {
-                // Ensure no duplicate answer_id for the same user when is_active == true
+                // Ensure no duplicate answer_id for the same user when is_active is true
                 $existing = UserProgress::where('user_id', $userProgress->user_id)
                     ->where('answer_id', $userProgress->answer_id)
                     ->where('is_active', true)
                     ->exists();
 
                 if ($existing) {
-                    // Generate a new answer_id to avoid duplication
-                    $userProgress->answer_id = Answer::factory()->create()->id;
+                    // Assign a new answer_id to avoid duplication from existing answers
+                    $userProgress->answer_id = Answer::inRandomOrder()->value('id') ?: Answer::factory()->create()->id;
                 }
             }
         });

--- a/database/seeders/AnswerSeeder.php
+++ b/database/seeders/AnswerSeeder.php
@@ -11,24 +11,32 @@ class AnswerSeeder extends Seeder
     /**
      * Run the database seeds.
      *
-     * This seeder creates a random number of answers (0-4) for each question.
+     * This seeder creates a random number (0-4) of unique answers for each question,
+     * ensuring that each answer label ('A', 'B', 'C', 'D') is unique per question.
      *
      * @return void
      */
     public function run()
     {
+        // Define possible labels
+        $labels = ['A', 'B', 'C', 'D'];
+
         // Fetch all questions
         $questions = Question::all();
 
         foreach ($questions as $question) {
-            // Create between 0 and 4 answers randomly for each question
-            $answerCount = random_int(0, 4);
+            // Create between 1 and 4 unique answers for each question
+            $answerCount = random_int(1, count($labels));
             
-            if ($answerCount > 0) {
+            // Shuffle labels and take the required number
+            $assignedLabels = collect($labels)->shuffle()->take($answerCount)->toArray();
+
+            foreach ($assignedLabels as $label) {
                 Answer::factory()
-                    ->count($answerCount)
                     ->for($question)
-                    ->create();
+                    ->create([
+                        'label' => $label,
+                    ]);
             }
         }
     }

--- a/database/seeders/ExamSetSeeder.php
+++ b/database/seeders/ExamSetSeeder.php
@@ -24,14 +24,25 @@ class ExamSetSeeder extends Seeder
     /**
      * Run the database seeds.
      *
-     * Creates a hierarchical structure of ExamSets.
+     * Creates multiple root ExamSets and their hierarchical structures.
      *
      * @return void
      */
     public function run()
     {
-        // Start by creating top-level ExamSets
-        $this->createExamSets(null, 1);
+        // Determine number of top-level ExamSets
+        $rootExamSetCount = random_int(2, 5);
+
+        for ($i = 0; $i < $rootExamSetCount; $i++) {
+            // Create a top-level ExamSet
+            $examSet = ExamSet::factory()->create([
+                'parent_id' => null,
+                // 'is_exam' is set by the factory
+            ]);
+
+            // Recursively create child ExamSets
+            $this->createExamSets($examSet->id, 2);
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request introduces several key improvements and fixes to seeder and factory logic, aimed at ensuring data consistency, preventing unintended model creation, and adhering to database constraints:

- **Fix `parent_id` Assignment in `ExamSetFactory`**: 
  - Removed incorrect usage of Faker for `parent_id` assignment.
  - Added a state callback to conditionally create parent ExamSets with `is_exam` set to `false`, ensuring proper hierarchical relationships.
  - Managed `parent_id` values in `ExamSetSeeder` to ensure they are valid integers or `null`.

- **Ensure Unique Answer Labels in Seeder**: 
  - Updated `AnswerSeeder` to assign unique labels ('A', 'B', 'C', 'D') for each question, preventing duplicates and adhering to the unique constraint on `['label', 'question_id']`.

- **Fix Type-hint and Table Reference in `UserProgressFactory`**:
  - Corrected the closure type-hint in `UserProgressFactory` to `UserProgress`, resolving type mismatch during seeding.
  - Updated the `UserProgress` model to use the correct table name (`user_progresses`).

- **Generate Multiple Root ExamSets in Seeder**: 
  - Modified `ExamSetSeeder` to create between 2 and 5 top-level ExamSets with `null` `parent_id`, maintaining the hierarchical structure.

- **Prevent Unintended Model Creation**: 
  - Refactored various factories (e.g., `QuestionFactory`, `AnswerFactory`, `UserProgressFactory`) to prevent the automatic creation of related models unless explicitly required by seeders.

- **Improve `answer_id` Assignment in `UserProgressFactory`**: 
  - Updated logic to ensure valid `answer_id` assignment, creating new answers if necessary, and resolving issues caused by assigning factory instances instead of IDs.

- **Ensure Slug Uniqueness Within Parent Scope**: 
  - Added slug generation methods in `QuestionFactory` and `ExamSetFactory` to ensure unique slugs within the appropriate parent scope (by `exam_set_id` or `parent_id`), resolving potential conflicts due to database constraints.

- **Remove Redundant Timestamp Assignments**: 
  - Removed unnecessary explicit assignments of `created_at` and `updated_at` in several factories, relying on Eloquent’s automatic timestamp management.

These changes collectively improve the accuracy and efficiency of the database seeding process, ensuring proper data relationships, uniqueness constraints, and preventing unintended data generation during testing or development.