### PR TITLE
Remove Unique Label Constraint from Answers Table

### DIFF
--- a/database/factories/AnswerFactory.php
+++ b/database/factories/AnswerFactory.php
@@ -15,8 +15,8 @@ class AnswerFactory extends Factory
     public function definition()
     {
         return [
-            'label' => strtoupper($this->faker->randomElement(['A', 'B', 'C', 'D'])),
-            'content' => $this->faker->sentence(),
+            'label' => $this->faker->optional()->randomElement(['A', 'B', 'C', 'D']),
+            'content' => $this->faker->option()->sentence(),
             'image_src' => $this->faker->optional()->imageUrl(),
             'image_alt' => $this->faker->optional()->words(3, true),
             'is_correct' => $this->faker->boolean(25), // 25% chance of being correct

--- a/database/factories/AnswerFactory.php
+++ b/database/factories/AnswerFactory.php
@@ -16,7 +16,7 @@ class AnswerFactory extends Factory
     {
         return [
             'label' => $this->faker->optional()->randomElement(['A', 'B', 'C', 'D']),
-            'content' => $this->faker->option()->sentence(),
+            'content' => $this->faker->optional()->sentence(),
             'image_src' => $this->faker->optional()->imageUrl(),
             'image_alt' => $this->faker->optional()->words(3, true),
             'is_correct' => $this->faker->boolean(25), // 25% chance of being correct

--- a/database/migrations/2024_10_24_104134_create_answers_table.php
+++ b/database/migrations/2024_10_24_104134_create_answers_table.php
@@ -23,8 +23,6 @@ return new class extends Migration
             $table->boolean('is_correct')->default(false);
             $table->timestamp('created_at')->useCurrent();
             $table->timestamp('updated_at')->useCurrentOnUpdate()->useCurrent();
-
-            $table->unique(['label', 'question_id'], 'unique_label_per_question');
         });
     }
 

--- a/database/seeders/AnswerSeeder.php
+++ b/database/seeders/AnswerSeeder.php
@@ -11,33 +11,24 @@ class AnswerSeeder extends Seeder
     /**
      * Run the database seeds.
      *
-     * This seeder creates a random number (0-4) of unique answers for each question,
-     * ensuring that each answer label ('A', 'B', 'C', 'D') is unique per question.
+     * This seeder creates a random number (0-4) of answers for each question,
+     * allowing duplicate labels and NULL values for labels by leveraging the factory's optional label.
      *
      * @return void
      */
     public function run()
     {
-        // Define possible labels
-        $labels = ['A', 'B', 'C', 'D'];
-
         // Fetch all questions
         $questions = Question::all();
 
         foreach ($questions as $question) {
-            // Create between 1 and 4 unique answers for each question
-            $answerCount = random_int(1, count($labels));
-            
-            // Shuffle labels and take the required number
-            $assignedLabels = collect($labels)->shuffle()->take($answerCount)->toArray();
+            // Create between 0 and 4 answers for each question
+            $answerCount = random_int(0, 4);
 
-            foreach ($assignedLabels as $label) {
-                Answer::factory()
-                    ->for($question)
-                    ->create([
-                        'label' => $label,
-                    ]);
-            }
+            Answer::factory()
+                ->count($answerCount)
+                ->for($question)
+                ->create();
         }
     }
 }


### PR DESCRIPTION
This pull request introduces the following changes to the answers table and its related components:

1. **Removal of Unique Label Constraint**:
   - The unique index `unique_label_per_question` has been eliminated, allowing duplicate labels for answers within the same question. This change accommodates scenarios where multiple answers might share the same label.

2. **Updated AnswerFactory**:
   - Modified the AnswerFactory to permit `NULL` values for the 'content' and 'label' attributes. This is achieved by utilizing Faker's `optional()` method, enabling more flexible answer generation.

3. **Refactored AnswerSeeder**:
   - The AnswerSeeder has been refactored for clarity and simplicity. It now directly utilizes the factory's count method to generate a random number of answers (ranging from 0 to 4) for each question. This enhances code readability while preserving the functionality of allowing NULL labels.

These changes aim to improve the overall flexibility and maintainability of the answer generation process while ensuring that the data model aligns with the updated requirements. Please review and provide feedback!