### PR TITLE
Refactor `exam_sets` Table: Implement ENUM Types for Sorting Fields

### DIFF
--- a/database/factories/ExamSetFactory.php
+++ b/database/factories/ExamSetFactory.php
@@ -13,6 +13,19 @@ class ExamSetFactory extends Factory
 {
     protected $model = \App\Models\ExamSet::class;
 
+    /**
+     * Available options for sorting.
+     *
+     * @var array
+     */
+    protected $sortByOptions = ['id', 'name', 'slug', 'created_at', 'updated_at'];
+    protected $sortOrderOptions = ['ASC', 'DESC'];
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
     public function definition()
     {
         $name = $this->faker->words(3, true);
@@ -27,8 +40,8 @@ class ExamSetFactory extends Factory
             'name' => $name,
             'slug' => $slug,
             'is_exam' => $this->faker->boolean(50),
-            'children_sort_by' => 'id',
-            'children_sort_order' => 'ASC',
+            'children_sort_by' => $this->faker->randomElement($this->sortByOptions),
+            'children_sort_order' => $this->faker->randomElement($this->sortOrderOptions),
         ];
     }
 

--- a/database/migrations/2024_10_24_104134_create_exam_sets_table.php
+++ b/database/migrations/2024_10_24_104134_create_exam_sets_table.php
@@ -19,8 +19,8 @@ return new class extends Migration
             $table->string('name');
             $table->string('slug');
             $table->boolean('is_exam')->default(false);
-            $table->string('children_sort_by', 64)->default('id');
-            $table->string('children_sort_order', 4)->default('ASC');
+            $table->enum('children_sort_by', ['id', 'name', 'slug', 'created_at', 'updated_at'])->default('id');
+            $table->enum('children_sort_order', ['ASC', 'DESC'])->default('ASC');
             $table->timestamp('created_at')->useCurrent();
             $table->timestamp('updated_at')->useCurrentOnUpdate()->useCurrent();
 


### PR DESCRIPTION
This pull request introduces changes to the `exam_sets` table by updating the `children_sort_by` and `children_sort_order` columns to use ENUM types. These changes aim to enhance data integrity and consistency within the database.

#### Changes Made:
- **Updated Database Schema**: 
  - Altered the `children_sort_by` column to ENUM type with the following predefined options: `id`, `name`, `slug`, `created_at`, `updated_at`.
  - Altered the `children_sort_order` column to ENUM type with the predefined options: `ASC`, `DESC`.

- **Modified ExamSetFactory**: 
  - Updated the factory to utilize ENUM options for the `children_sort_by` and `children_sort_order` fields, ensuring alignment with the new database constraints.

#### Benefits:
- Ensures that only valid sorting options can be stored in the database, reducing the likelihood of errors due to invalid input.
- Simplifies the sorting logic in the application by enforcing predefined sorting criteria.