### PR TITLE
Add Answer Sorting Fields to Questions Table and Update Model and Factory

### DIFF
--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -30,6 +30,8 @@ class Question extends Model
         'content',
         'image_src',
         'image_alt',
+        'answers_sort_by',
+        'answers_sort_order',
     ];
 
     /**

--- a/database/factories/QuestionFactory.php
+++ b/database/factories/QuestionFactory.php
@@ -29,6 +29,8 @@ class QuestionFactory extends Factory
             'content' => $this->faker->paragraph(),
             'image_src' => $this->faker->optional()->imageUrl(),
             'image_alt' => $this->faker->optional()->words(3, true),
+            'answers_sort_by' => $this->faker->randomElement(['id', 'label', 'content', 'created_at', 'updated_at']),
+            'answers_sort_order' => $this->faker->randomElement(['ASC', 'DESC', 'RAND']),
         ];
     }
 

--- a/database/migrations/2024_10_24_104134_create_questions_table.php
+++ b/database/migrations/2024_10_24_104134_create_questions_table.php
@@ -21,6 +21,8 @@ return new class extends Migration
             $table->text('content')->nullable();
             $table->string('image_src')->nullable();
             $table->string('image_alt')->nullable();
+            $table->enum('answers_sort_by', ['id', 'label', 'content', 'created_at', 'updated_at'])->default('id');
+            $table->enum('answers_sort_order', ['ASC', 'DESC', 'RAND'])->default('ASC');
             $table->timestamp('created_at')->useCurrent();
             $table->timestamp('updated_at')->useCurrentOnUpdate()->useCurrent();
 


### PR DESCRIPTION
This pull request introduces new functionality to the `questions` table by adding the `answers_sort_by` and `answers_sort_order` fields, enabling customizable sorting of answers. The following changes were made:

- **Database Changes:**
  - Added `answers_sort_by` and `answers_sort_order` as enum fields in the `questions` table.
  - Allowed values for `answers_sort_by`: `id`, `label`, `content`, `created_at`, `updated_at`.
  - Allowed values for `answers_sort_order`: `ASC`, `DESC`, `RAND`.
  - Set default values for both fields to ensure consistent behavior.

- **Model Changes:**
  - Updated the `Question` model by adding `answers_sort_by` and `answers_sort_order` to the `$fillable` array to allow mass assignment.
  
- **Factory Changes:**
  - Updated the `QuestionFactory` to randomly assign valid values to `answers_sort_by` and `answers_sort_order`, ensuring that test data includes sorting options.

These updates will allow administrators to control how answers are sorted when retrieving them in relation to specific questions, enhancing query flexibility.