### PR TITLE
Implement Contributors Page

### DIFF
--- a/resources/views/pages/contributors.blade.php
+++ b/resources/views/pages/contributors.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.app')
+
+@section('content')
+    <main>
+        <div class="container pb-4 pb-xl-5">
+            <div class="row mb-5">
+                <div class="col-md-8 col-xl-6 text-center mx-auto">
+                    <h1 class="fw-bold">Development</h1>
+                </div>
+            </div>
+            <div class="row gy-5 row-cols-1 row-cols-lg-2 row-cols-xxl-3 mb-5">
+                <div class="col">
+                    <div class="card border-0">
+                        <div class="card-body d-flex align-items-center p-0">
+                            <img class="rounded-circle me-3 object-fit-cover" src="https://avatars.githubusercontent.com/u/90804797?v=4" height="130" width="130" alt="Profile picture of mikaelvincent.dev">
+                            <div>
+                                <h3 class="fw-bold mb-0">mikaelvincent.dev</h3>
+                                <p class="font-monospace text-muted mb-1">mikaelvincent</p>
+                                <a href="https://github.com/mikaelvincent" target="_blank">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" viewBox="0 0 16 16" class="bi bi-github fs-2">
+                                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8"></path>
+                                    </svg>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row mb-5">
+                <div class="col">
+                    <hr>
+                </div>
+            </div>
+            <div class="row mb-5">
+                <div class="col-md-8 col-xl-6 text-center mx-auto">
+                    <h1 class="fw-bold">Funding</h1>
+                </div>
+            </div>
+            <div class="row gy-5 row-cols-1 row-cols-lg-2 row-cols-xxl-3 mb-5">
+                <div class="col">
+                    <div class="card border-0">
+                        <div class="card-body d-flex align-items-center p-0">
+                            <img class="rounded-circle me-3 object-fit-cover" src="https://avatars.githubusercontent.com/u/90804797?v=4" height="130" width="130" alt="Profile picture of mikaelvincent.dev">
+                            <div>
+                                <h3 class="fw-bold mb-0">mikaelvincent.dev</h3>
+                                <p class="font-monospace text-muted mb-1">mikaelvincent</p>
+                                <a href="https://github.com/mikaelvincent" target="_blank">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" viewBox="0 0 16 16" class="bi bi-github fs-2">
+                                        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8"></path>
+                                    </svg>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,12 @@ Route::get('/', function () {
 });
 
 Route::get('/contributors', function () {
-    return view('contributors');
+    $breadcrumbs = [
+        ['name' => 'Home', 'url' => '/'],
+        ['name' => 'Contributors', 'url' => null],
+    ];
+
+    return view('pages.contributors', compact('breadcrumbs'));
 });
 
 Route::get('/{any}', [ContentResolverController::class, 'resolve'])


### PR DESCRIPTION
This pull request adds a new contributors page to the application, showcasing the contributors' information in a visually appealing format. The following changes have been made:

- **Contributors Page**: 
  - Created `resources\views\pages\contributors.blade.php` to display contributors using Bootstrap cards, which include GitHub links for each contributor.
  
- **Routing**:
  - Updated `routes\web.php` to include a new route for `/contributors`, along with corresponding breadcrumb data for easy navigation.

### Features:
- Displays a list of contributors with their GitHub profiles.

This implementation enhances the visibility of our contributors and promotes community engagement through direct links to their GitHub profiles.